### PR TITLE
Upload Artifacts 

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -36,7 +36,7 @@ jobs:
         distribution: 'temurin'
     - run: mvn --batch-mode --update-snapshots verify
     - run: mkdir staging && cp target/*.jar staging
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: Package
         path: staging

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # java_maven_project
 This is simple java maven project for github actions
+


### PR DESCRIPTION
GitHub has deprecated the version of the upload-artifact action you’re using. According to the deprecation notice published by GitHub, v3 of actions/upload-artifact is no longer supported and will cause workflows to fail automatically. You can find detailed instructions on how to update your workflow in the GitHub changelog here: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

I updated the version to v4.